### PR TITLE
Fix multi-sort

### DIFF
--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -744,7 +744,7 @@ BootstrapTable.prototype.onMultipleSort = function () {
     return cmp(arr1, arr2)
   }
 
-  this.data.sort((a, b) => arrayCmp(a, b))
+  this.options.data.sort((a, b) => arrayCmp(a, b))
 
   this.initBody()
   this.assignSortableArrows()


### PR DESCRIPTION
this.data is change, then this.initBody() load this.options.data, so reorder this.options.data instead

**Bug fix?**
yes

**New Feature?**
no

**Resolve an issue?**
Fix #4616

**Example(s)?**
Do manual asc on both columns
Before: https://live.bootstrap-table.com/code/wenzhixin/853
After: https://live.bootstrap-table.com/code/Naruto-kyun/5802
